### PR TITLE
docs: expand CLAUDE.md with full route map, collections, and functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,17 @@ Public website (`senoiahistory.com`) and admin portal (`admin.senoiahistory.com`
 | Build | Vite 8, TypeScript 5.9 |
 | Frontend | React 19, React Router 7 |
 | Styling | Tailwind CSS 3.4 + `@tailwindcss/typography` |
-| Rich text | TipTap v3 (starter-kit, link, image, underline, text-align, youtube) |
+| Rich text | TipTap v3 (starter-kit, link, image, underline, text-align, youtube + custom iframe) |
 | Icons | Lucide React |
+| Forms | react-hook-form v7 |
+| Dates | date-fns v4 |
 | Auth | Firebase Auth — Google OAuth, `@senoiahistory.com` accounts only |
 | Database | Cloud Firestore — **default database** |
 | Storage | Firebase Storage (bucket shared with archive-app) |
 | Functions | Cloud Functions v2, TypeScript, Node 24, codebase `website` |
 | Payments | Stripe Checkout |
 | Email | Resend + React Email v6 |
+| Calendar | Google Calendar API (event/booking sync via service account) |
 | Gallery lightbox | yet-another-react-lightbox |
 | Testing | Vitest (unit) + Playwright (E2E) |
 
@@ -38,6 +41,16 @@ Permanent admins (hardcoded): `catnolan@senoiahistory.com`, `jeremywarren@senoia
 
 Role overrides: Firestore `user_roles/{email}` document → `admin > curator > editor > read_only`
 
+Role flags exposed via `AuthContext` (`src/contexts/AuthContext.tsx`):
+
+| Flag | Who has it |
+|---|---|
+| `isAdmin` | Permanent admins + `admin` role override |
+| `isCurator` | Admins + `curator` role override |
+| `isEditor` | Curators + `editor` role override |
+| `isReadOnly` | All roles including `read_only` / `board_member` |
+| `isSAHSUser` | Any authenticated user with any role (gate for `/admin/*`) |
+
 Both apps read `user_roles` from the **default Firestore** (same collection, shared logic). `ProtectedRoute` wraps all `/admin/*` routes. Admin subdomain auto-redirects to `/admin/content`. Firestore and Storage rules mirror this via `isSAHSUser()`, `isEditor()`, `isCurator()`, `isAdmin()` helpers.
 
 ## Membership & Stripe
@@ -46,28 +59,123 @@ Tiers: Sustaining ($25,000/yr) · Family Senior ($75) · Family ($50) · Individ
 
 Flow: Stripe Checkout → `stripeWebhook` function → Resend welcome email → contact added to Resend Audience (`RESEND_AUDIENCE_ID` = `725e0bbc-33c0-4bc4-a2de-3252c0ab757c` in Secret Manager). Backfill existing members: `node scripts/backfill_resend_members.cjs`
 
+## Firestore Collections
+
+| Collection | Description | Access |
+|---|---|---|
+| `posts` | News articles and events (TipTap HTML content, ticketing fields) | Public read published; editors+ write |
+| `galleries` | Photo galleries with cover image, ordered by `sortOrder` | Public read; editors+ write |
+| `historical_places` | Museum exhibit database with coordinates | Public read; editors+ write |
+| `organization_entities` | Board members (`board_member`), corporate sponsors (`corporate_sponsor`), event sponsors (`event_sponsor`) | Public read; editors+ write |
+| `bookings` | Meeting room rental requests — pending/confirmed/cancelled | Public read confirmed; curators manage |
+| `memberships` | Member records created by Stripe webhook | Curators only |
+| `tickets` | Event ticket purchases with QR codes | Public lookup by stripeSessionId (limit 1); curators manage |
+| `submissions` | Vendor and sponsor application forms | Public create-only; curators read |
+| `volunteer_sheets` | Volunteer signup campaigns — draft/active/closed | Active sheets public read; editors manage |
+| `volunteer_sheets/{id}/slots` | Time slots within a volunteer sheet | Public read active; editors manage |
+| `volunteer_sheets/{id}/registrations` | Individual volunteer signups | Public create; editors read |
+| `shortlinks` | Custom 301 redirect slugs | Admin only |
+| `user_roles` | Role overrides by email address | Self-read; admin-write |
+| `mail` | Trigger Email extension queue | Public create; no read |
+| `wiki` | Internal knowledge base articles | Editors+ only |
+
 ## Critical File Map
 
 | File | Purpose |
 |---|---|
 | `src/lib/firebase.ts` | Firebase init; auto-connects emulators on localhost |
-| `src/services/api.ts` | All Firestore read/write operations |
+| `src/services/api.ts` | All Firestore read/write operations (20KB+) |
 | `src/services/storage.ts` | Firebase Storage upload helpers |
-| `src/contexts/AuthContext.tsx` | Auth state and role flags (`isAdmin`, `isCurator`, `isEditor`, `isSAHSUser`) |
+| `src/contexts/AuthContext.tsx` | Auth state and role flags (`isAdmin`, `isCurator`, `isEditor`, `isReadOnly`, `isSAHSUser`) |
+| `src/types/index.ts` | TypeScript interfaces for all data models (Post, Membership, Ticket, Gallery, etc.) |
 | `src/App.tsx` | All routes — public and admin |
-| `src/pages/admin/ContentAdmin.tsx` | Primary admin UI (~49KB — content, gallery, drafts) |
-| `src/pages/admin/AdminHeader.tsx` | Admin nav — add new nav items to `navGroups` here |
-| `src/components/admin/RichTextEditor.tsx` | TipTap editor (link/image/YouTube/iframe) |
 | `src/index.css` | Global styles, Tailwind overrides, `.prose a` link styling |
-| `functions/src/index.ts` | All Cloud Functions |
+| `src/pages/admin/ContentAdmin.tsx` | Primary admin UI (~49KB — posts, galleries, drafts) |
+| `src/pages/admin/AdminHeader.tsx` | Admin nav — add new nav items to `navGroups` here |
+| `src/pages/admin/AdminDashboard.tsx` | Admin home — stats and quick links |
+| `src/pages/admin/WikiAdmin.tsx` | Internal knowledge base CRUD |
+| `src/pages/admin/VolunteersAdmin.tsx` | Volunteer sheet and signup management (~27KB) |
+| `src/components/admin/RichTextEditor.tsx` | TipTap editor (link/image/YouTube/iframe) |
+| `src/components/admin/extensions/Iframe.ts` | Custom TipTap extension for YouTube iframes |
+| `functions/src/index.ts` | All Cloud Functions (680+ lines) |
 | `functions/src/emails/WelcomeEmail.tsx` | React Email welcome template |
 | `functions/src/emails/NewsletterEmail.tsx` | React Email newsletter template |
 | `firestore.rules` | Security rules — mirrors auth role logic |
 | `scripts/` | Ad-hoc Firestore maintenance scripts |
 
-## Admin Routes
+## Routes
 
-`/admin/login` · `/admin` · `/admin/content` · `/admin/bookings` · `/admin/memberships` · `/admin/tickets` · `/admin/tickets/scan` · `/admin/wiki` · `/admin/volunteers` · `/admin/shortlinks` · `/admin/newsletter` · `/admin/users`
+### Admin Routes (all protected by `ProtectedRoute` — requires `isSAHSUser`)
+
+| Path | Component | Notes |
+|---|---|---|
+| `/admin/login` | `Login.tsx` | Unprotected — Google OAuth |
+| `/admin` | `AdminDashboard.tsx` | Stats and quick links |
+| `/admin/content` | `ContentAdmin.tsx` | Primary content editor |
+| `/admin/bookings` | `BookingsAdmin.tsx` | Room booking management |
+| `/admin/memberships` | `MembershipsAdmin.tsx` | Member database (Stripe) |
+| `/admin/tickets` | `TicketsAdmin.tsx` | Ticket sales history |
+| `/admin/tickets/scan` | `TicketScanner.tsx` | QR code verification |
+| `/admin/wiki` | `WikiAdmin.tsx` | Internal knowledge base |
+| `/admin/volunteers` | `VolunteersAdmin.tsx` | Volunteer signup management |
+| `/admin/shortlinks` | `ShortLinksAdmin.tsx` | Custom URL manager |
+| `/admin/newsletter` | `NewsletterComposer.tsx` | Email builder + broadcast |
+| `/admin/users` | `UsersAdmin.tsx` | Role assignments (admin only) |
+
+Admin subdomain (`admin.senoiahistory.com`) auto-redirects to `/admin/content` via `HostnameRedirect` in `App.tsx`.
+
+### Public Routes (all wrapped in `PublicLayout` — Header + Footer)
+
+| Path | Component | Notes |
+|---|---|---|
+| `/` | `Home.tsx` | Hero + latest news feed |
+| `/about-sahs` | `About.tsx` | Board members and history |
+| `/senoia-stories` | `SenoiaStories.tsx` | Historical content |
+| `/location-and-hours` | `LocationAndHours.tsx` | Museum info |
+| `/carmichael-house` | `CarmichaelHouse.tsx` | Venue details |
+| `/contact-sahs` | `Contact.tsx` | Contact form |
+| `/privacy-policy` | `PrivacyPolicy.tsx` | |
+| `/news` | `News.tsx` | News + events list with filters |
+| `/news/:slug` | `NewsDetail.tsx` | Single post view |
+| `/support-sahs` | `Support.tsx` | Membership tier selection + Stripe |
+| `/support-sahs/success` | `StripeSuccess.tsx` | Post-payment confirmation |
+| `/support-sahs/cancel` | `StripeCancel.tsx` | |
+| `/supporters` | `Supporters.tsx` | Member and sponsor listing |
+| `/meeting-room` | `MeetingRoom.tsx` | Room booking form |
+| `/meeting-room/success` | `BookingSuccess.tsx` | |
+| `/meeting-room/cancel` | `BookingCancel.tsx` | |
+| `/vendor-application-form` | `VendorApplication.tsx` | |
+| `/sponsor-application-form` | — | Redirects to `/support-sahs#memberships` |
+| `/historic-structures-and-places` | `HistoricalPlaces.tsx` | Map-based place browser |
+| `/historic-structures-and-places/:slug` | `HistoricalPlaceDetail.tsx` | |
+| `/media` | `Media.tsx` | Photo gallery lightbox |
+| `/past-sahs-events` | `PastEvents.tsx` | Historical event archive |
+| `/volunteer/:token` | `VolunteerSignup.tsx` | Public volunteer slot signup |
+| `/tickets/success` | `TicketSuccess.tsx` | QR code display post-purchase |
+| `/membership-status` | `MemberPortal.tsx` | Self-service membership lookup |
+| `/box-office` | `BoxOffice.tsx` | Admin ticket sales at the door |
+| `/401` | `Unauthorized.tsx` | |
+| `*` | `NotFound.tsx` | 404 fallback |
+
+## Cloud Functions (`functions/src/index.ts`)
+
+All HTTP functions use `onRequest({ cors: true, secrets: [...] })`.
+
+| Function | Trigger | Purpose |
+|---|---|---|
+| `checkCalendarAvailability` | HTTP POST | Google Calendar free/busy query for meeting room |
+| `createBookingCheckoutSession` | HTTP POST | Creates pending booking doc + Stripe checkout ($50) |
+| `createMembershipCheckoutSession` | HTTP POST | Stripe checkout for membership tiers |
+| `createTicketCheckoutSession` | HTTP POST | Stripe checkout for event tickets |
+| `listStripeSubscriptions` | HTTP GET/POST | Lists all Stripe subscriptions for admin view |
+| `stripeWebhook` | HTTP POST | Handles `checkout.session.completed` — creates membership/ticket/booking records, sends welcome email, adds Resend contact |
+| `verifyTicket` | HTTP GET/POST | QR scanner endpoint — validates ticket by `confirmationNumber` |
+| `onBookingConfirmed` | Firestore trigger | Watches `bookings/{id}` status → `confirmed`; inserts Google Calendar event |
+| `onPostWritten` | Firestore trigger | Watches `posts/{id}` type=`event`; syncs create/update/delete to Google Calendar |
+| `getMembershipByEmail` | HTTP GET/POST | Self-service Stripe lookup by email |
+| `renderEmailPreview` | HTTP POST | Returns rendered HTML for admin email preview iframe |
+| `sendNewsletter` | HTTP POST | Test send or Resend broadcast to audience |
+| `shortlinkRedirect` | HTTP GET | `shortlinks` → `posts` → homepage fallback 301 redirect |
 
 ## Common Edit Patterns
 
@@ -89,8 +197,14 @@ Flow: Stripe Checkout → `stripeWebhook` function → Resend welcome email → 
 **Styling**
 - Global base and utilities: `src/index.css`
 - Color tokens: `cream`, `charcoal`, `tan`, `tan-dark`, `tan-light` (defined in `tailwind.config.js`)
+- Fonts: Playfair Display (serif headings), Inter (sans body)
 - `.prose a` in `src/index.css` controls hyperlink appearance in public post content rendered from TipTap HTML
 - Admin form inputs use `.input-base` utility class
+
+**Adding a new data type**
+1. Add the interface to `src/types/index.ts`
+2. Add read/write helpers to `src/services/api.ts`
+3. Add Firestore security rules to `firestore.rules`
 
 ## Commands
 
@@ -100,6 +214,8 @@ npm run emulators        # Firebase emulators with persisted data (import/export
 npm run build            # TypeScript compile + Vite production build
 npm run lint             # ESLint
 npm test                 # Vitest unit tests
+npm run test:watch       # Vitest in watch mode
+npm run test:ui          # Vitest with browser UI
 npm run test:e2e:local   # Playwright E2E against localhost:5173
 npx tsx scripts/<name>.ts   # One-off TypeScript Firestore scripts
 node scripts/<name>.cjs     # One-off CJS Firestore scripts
@@ -112,6 +228,7 @@ npm run build
 firebase deploy --only hosting        # dist/ → Firebase Hosting (both targets)
 firebase deploy --only functions      # Cloud Functions (website codebase)
 firebase deploy --only firestore:rules
+firebase deploy --only storage        # Storage rules
 ```
 
 ## Gotchas
@@ -137,3 +254,5 @@ firebase deploy --only firestore:rules
 **Functions don't hot-reload** — After editing `functions/src/`, rebuild (`cd functions && npm run build`) and restart the emulator.
 
 **Lightbox CSS must be imported explicitly** — `import 'yet-another-react-lightbox/styles.css'`. Each plugin (e.g. Counter) has its own import.
+
+**Volunteer slot capacity is maintained via transaction** — `filledCount` on `VolunteerSlot` is incremented atomically via Firestore transaction on public signup. Never write it directly outside that path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,38 +124,6 @@ Flow: Stripe Checkout → `stripeWebhook` function → Resend welcome email → 
 
 Admin subdomain (`admin.senoiahistory.com`) auto-redirects to `/admin/content` via `HostnameRedirect` in `App.tsx`.
 
-### Public Routes (all wrapped in `PublicLayout` — Header + Footer)
-
-| Path | Component | Notes |
-|---|---|---|
-| `/` | `Home.tsx` | Hero + latest news feed |
-| `/about-sahs` | `About.tsx` | Board members and history |
-| `/senoia-stories` | `SenoiaStories.tsx` | Historical content |
-| `/location-and-hours` | `LocationAndHours.tsx` | Museum info |
-| `/carmichael-house` | `CarmichaelHouse.tsx` | Venue details |
-| `/contact-sahs` | `Contact.tsx` | Contact form |
-| `/privacy-policy` | `PrivacyPolicy.tsx` | |
-| `/news` | `News.tsx` | News + events list with filters |
-| `/news/:slug` | `NewsDetail.tsx` | Single post view |
-| `/support-sahs` | `Support.tsx` | Membership tier selection + Stripe |
-| `/support-sahs/success` | `StripeSuccess.tsx` | Post-payment confirmation |
-| `/support-sahs/cancel` | `StripeCancel.tsx` | |
-| `/supporters` | `Supporters.tsx` | Member and sponsor listing |
-| `/meeting-room` | `MeetingRoom.tsx` | Room booking form |
-| `/meeting-room/success` | `BookingSuccess.tsx` | |
-| `/meeting-room/cancel` | `BookingCancel.tsx` | |
-| `/vendor-application-form` | `VendorApplication.tsx` | |
-| `/sponsor-application-form` | — | Redirects to `/support-sahs#memberships` |
-| `/historic-structures-and-places` | `HistoricalPlaces.tsx` | Map-based place browser |
-| `/historic-structures-and-places/:slug` | `HistoricalPlaceDetail.tsx` | |
-| `/media` | `Media.tsx` | Photo gallery lightbox |
-| `/past-sahs-events` | `PastEvents.tsx` | Historical event archive |
-| `/volunteer/:token` | `VolunteerSignup.tsx` | Public volunteer slot signup |
-| `/tickets/success` | `TicketSuccess.tsx` | QR code display post-purchase |
-| `/membership-status` | `MemberPortal.tsx` | Self-service membership lookup |
-| `/box-office` | `BoxOffice.tsx` | Admin ticket sales at the door |
-| `/401` | `Unauthorized.tsx` | |
-| `*` | `NotFound.tsx` | 404 fallback |
 
 ## Cloud Functions (`functions/src/index.ts`)
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **Firestore Collections** section documenting all 15 collections with descriptions and access-control notes
- Adds a **Routes** section covering every admin and public route in table form (was previously just a one-liner list of admin routes)
- Adds a **Cloud Functions** section documenting all 13 functions with their trigger type and purpose
- Expands the **Critical File Map** with previously missing files (`src/types/index.ts`, `AdminDashboard.tsx`, `WikiAdmin.tsx`, `VolunteersAdmin.tsx`, custom TipTap iframe extension)
- Adds Google Calendar API and `date-fns` to the **Tech Stack** table
- Adds a **role flags table** to the Auth & Role System section
- Adds an "Adding a new data type" pattern to **Common Edit Patterns**
- Documents the volunteer slot `filledCount` transaction invariant as a new **Gotcha**

## Test plan

- [ ] Verify all route paths match `src/App.tsx`
- [ ] Verify all Firestore collections match `firestore.rules` and `src/services/api.ts`
- [ ] Verify all Cloud Functions match `functions/src/index.ts`

https://claude.ai/code/session_017Kw6XfhjJZXp3DtdcKi9zs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Kw6XfhjJZXp3DtdcKi9zs)_