### PR TITLE
Unpublish Ellis Crook program listing

### DIFF
--- a/functions/unpublish-post.ts
+++ b/functions/unpublish-post.ts
@@ -1,0 +1,30 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const slug = process.argv[2];
+if (!slug) {
+  console.error('Usage: npx tsx unpublish-post.ts <slug>');
+  process.exit(1);
+}
+
+initializeApp({
+  credential: cert(process.env.GOOGLE_APPLICATION_CREDENTIALS || `${process.env.HOME}/.config/gcloud/sahs-firebase-deploy.json`),
+  projectId: 'sahs-archives'
+});
+
+const db = getFirestore();
+
+async function main() {
+  const snap = await db.collection('posts').where('slug', '==', slug).limit(1).get();
+  if (snap.empty) {
+    console.error(`No post found with slug: ${slug}`);
+    process.exit(1);
+  }
+
+  const doc = snap.docs[0];
+  console.log(`Found post: "${doc.data().title}" (${doc.id}) — status: ${doc.data().status}`);
+  await doc.ref.update({ status: 'draft' });
+  console.log('Post unpublished (status set to draft).');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds a one-off utility script (`functions/unpublish-post.ts`) to set the July 2026 "Stories of Senoia with Ellis Crook" program listing to `draft`, taking it down from the public site while a replacement is arranged.

## How to run

From your local machine, inside `sahs-website/functions/`:

```bash
npx tsx unpublish-post.ts july-2026-program-stories-of-senoia-with-ellis-crook
```

The script uses `~/.config/gcloud/sahs-firebase-deploy.json` by default, or a path set via `GOOGLE_APPLICATION_CREDENTIALS`.

## Test plan

- [ ] Run the script locally and confirm output: `Post unpublished (status set to draft).`
- [ ] Verify `senoiahistory.com/news/july-2026-program-stories-of-senoia-with-ellis-crook` returns 404 / is no longer accessible
- [ ] Confirm the post appears as Draft in the admin Content panel

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZGsVbuKJoZvupR3dVD1uW)_