### PR TITLE
Fix admin portal empty-content bug: Firestore rules/indexes never deployed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,8 +56,33 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
 
-      # 🚀 Deploy to Firebase using the authenticated environment
-      - name: Deploy to Firebase Hosting, Functions, Firestore, and Storage
-        run: npx firebase-tools deploy --only hosting,functions,firestore:rules,firestore:indexes,storage --project sahs-archives --force
+      # 🚀 Deploy the app first — this is the well-established, previously-working
+      # path. Keeping it as its own step means a problem deploying rules/storage
+      # below (e.g. a missing IAM role for this service account) can't block the
+      # app from shipping.
+      - name: Deploy to Firebase Hosting and Functions
+        run: npx firebase-tools deploy --only hosting,functions --project sahs-archives --force
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+
+      # Validate firestore.rules and storage.rules before pushing them live. This
+      # repo has no rules-unit-test suite, so this dry run is the only automated
+      # check that catches a syntax/compile error before it reaches production.
+      - name: Validate Firestore & Storage rules (dry run)
+        run: npx firebase-tools deploy --only firestore:rules,storage --project sahs-archives --dry-run
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+
+      # Deploy Firestore rules and Storage rules. Firestore.rules previously only
+      # ever got deployed manually (or not at all), which let it silently drift out
+      # of sync with the app — this keeps it in sync on every merge to main.
+      #
+      # firestore:indexes is intentionally NOT deployed here: `firebase deploy
+      # --only firestore:indexes` is declarative and deletes any production index
+      # not listed in firestore.indexes.json, which is too destructive to run
+      # unattended on every push. Deploy index changes manually and deliberately
+      # with `firebase deploy --only firestore:indexes` per CLAUDE.md.
+      - name: Deploy Firestore & Storage rules
+        run: npx firebase-tools deploy --only firestore:rules,storage --project sahs-archives --force
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           export_environment_variables: true
 
       # 🚀 Deploy to Firebase using the authenticated environment
-      - name: Deploy to Firebase Hosting and Functions
-        run: npx firebase-tools deploy --only hosting,functions --project sahs-archives --force
+      - name: Deploy to Firebase Hosting, Functions, Firestore, and Storage
+        run: npx firebase-tools deploy --only hosting,functions,firestore:rules,firestore:indexes,storage --project sahs-archives --force
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}

--- a/firestore.rules
+++ b/firestore.rules
@@ -78,6 +78,9 @@ service cloud.firestore {
       }
     }
 
+    // Shortlinks: admin-managed custom redirect slugs
+    match /shortlinks/{doc} { allow read, write: if isAdmin(); }
+
     // Mail (Trigger Email extension): allow creation for all (even public for signups); deny read/update
     match /mail/{doc} {
       allow create: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,11 +3,13 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     // Helper functions: Flattened to avoid recursion and circular dependencies
+    // Admin = permanent hardcoded admins or an explicit 'admin' role override.
+    // Do NOT match on the @senoiahistory.com domain broadly here — that would grant
+    // every SAHS staff account admin rights regardless of their actual role.
     function isAdmin() {
       return request.auth != null && (
-        request.auth.token.email.lower() == 'catnolan@senoiahistory.com' || 
+        request.auth.token.email.lower() == 'catnolan@senoiahistory.com' ||
         request.auth.token.email.lower() == 'jeremywarren@senoiahistory.com' ||
-        request.auth.token.email.lower().matches('.*@senoiahistory\\.com$') ||
         (exists(/databases/$(database)/documents/user_roles/$(request.auth.token.email.lower())) &&
          get(/databases/$(database)/documents/user_roles/$(request.auth.token.email.lower())).data.role == 'admin')
       );

--- a/src/components/admin/ErrorBanner.tsx
+++ b/src/components/admin/ErrorBanner.tsx
@@ -1,0 +1,13 @@
+import { AlertCircle } from 'lucide-react';
+
+export default function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="mb-6 flex items-start gap-3 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+      <AlertCircle size={16} className="mt-0.5 shrink-0" />
+      <span>
+        {message} Check the browser console for details — this usually means a Firestore permissions or
+        index error rather than there being no data.
+      </span>
+    </div>
+  );
+}

--- a/src/pages/BoxOffice.tsx
+++ b/src/pages/BoxOffice.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
+import { collection, query, where, getDocs } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import type { Post } from '../types';
 import { useAuth } from '../contexts/AuthContext';
@@ -10,25 +10,28 @@ export default function BoxOffice() {
   const { user } = useAuth();
   const [events, setEvents] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     async function loadEvents() {
       try {
-        // Fetch posts that are events and have a ticket price
+        // Equality-only filters (no orderBy chained) so this never depends on a
+        // composite index existing — sort client-side instead.
         const q = query(
           collection(db, 'posts'),
           where('type', '==', 'event'),
-          where('status', '==', 'published'),
-          orderBy('eventDate', 'asc')
+          where('status', '==', 'published')
         );
         const snapshot = await getDocs(q);
         const fetchedEvents = snapshot.docs
           .map(doc => ({ id: doc.id, ...doc.data() } as Post))
-          .filter(event => event.ticketPrice && event.ticketPrice > 0);
-        
+          .filter(event => event.ticketPrice && event.ticketPrice > 0)
+          .sort((a, b) => (a.eventDate?.toMillis() ?? 0) - (b.eventDate?.toMillis() ?? 0));
+
         setEvents(fetchedEvents);
-      } catch (err) {
+      } catch (err: any) {
         console.error("Failed to load box office events", err);
+        setLoadError(err?.message || 'Failed to load events.');
       } finally {
         setLoading(false);
       }
@@ -52,6 +55,11 @@ export default function BoxOffice() {
         {loading ? (
           <div className="flex justify-center items-center py-24">
             <Loader2 className="animate-spin text-tan" size={48} />
+          </div>
+        ) : loadError ? (
+          <div className="bg-white rounded-xl border border-tan/20 p-12 text-center shadow-sm">
+            <p className="text-charcoal/50 font-sans italic text-lg">We couldn't load events right now.</p>
+            <p className="mt-2 text-charcoal/40 text-sm font-sans">Please try refreshing the page, or check back shortly.</p>
           </div>
         ) : events.length === 0 ? (
           <div className="bg-white rounded-xl border border-tan/20 p-12 text-center shadow-sm">

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -16,49 +16,67 @@ export default function AdminDashboard() {
   const [recentTickets, setRecentTickets] = useState<RecentTicket[]>([]);
   const [recentBookings, setRecentBookings] = useState<RecentBooking[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadErrors, setLoadErrors] = useState<string[]>([]);
 
   useEffect(() => {
     async function loadDashboard() {
       const now = new Date();
 
-      const [publishedSnap, draftSnap, archivedSnap, eventsSnap, ticketsSnap, bookingsSnap] = await Promise.all([
+      // Each query is settled independently so one failure (e.g. a permission
+      // or missing-index error) doesn't blank out the entire dashboard.
+      const results = await Promise.allSettled([
         getDocs(query(collection(db, 'posts'), where('status', '==', 'published'))),
         getDocs(query(collection(db, 'posts'), where('status', '==', 'draft'))),
         getDocs(query(collection(db, 'posts'), where('status', '==', 'archived'))),
-        getDocs(query(
-          collection(db, 'posts'),
-          where('type', '==', 'event'),
-          where('status', '==', 'published'),
-          orderBy('eventDate', 'asc'),
-          limit(4)
-        )),
+        // Equality-only filters (no orderBy chained) so this never depends on a
+        // composite index existing — sort/filter for "upcoming" client-side instead.
+        getDocs(query(collection(db, 'posts'), where('type', '==', 'event'), where('status', '==', 'published'))),
         getDocs(query(collection(db, 'tickets'), orderBy('purchasedAt', 'desc'), limit(5))),
         getDocs(query(collection(db, 'bookings'), orderBy('submittedAt', 'desc'), limit(5))),
       ]);
+      const [publishedRes, draftRes, archivedRes, eventsRes, ticketsRes, bookingsRes] = results;
+
+      const errors: string[] = [];
+      const labels = ['published posts', 'draft posts', 'archived posts', 'upcoming events', 'recent tickets', 'recent bookings'];
+      results.forEach((r, i) => {
+        if (r.status === 'rejected') {
+          console.error(`Dashboard: failed to load ${labels[i]}:`, r.reason);
+          errors.push(labels[i]);
+        }
+      });
+      setLoadErrors(errors);
 
       setPostCounts({
-        published: publishedSnap.size,
-        draft: draftSnap.size,
-        archived: archivedSnap.size,
+        published: publishedRes.status === 'fulfilled' ? publishedRes.value.size : 0,
+        draft: draftRes.status === 'fulfilled' ? draftRes.value.size : 0,
+        archived: archivedRes.status === 'fulfilled' ? archivedRes.value.size : 0,
       });
 
-      const events: UpcomingEvent[] = eventsSnap.docs
-        .map(d => ({ id: d.id, ...d.data() } as UpcomingEvent))
-        .filter(e => {
-          if (!e.eventDate) return true;
-          const eventDate = e.eventDate.toDate ? e.eventDate.toDate() : new Date(e.eventDate as any);
-          return eventDate >= now;
-        })
-        .slice(0, 3);
+      const events: UpcomingEvent[] = eventsRes.status === 'fulfilled'
+        ? eventsRes.value.docs
+            .map(d => ({ id: d.id, ...d.data() } as UpcomingEvent))
+            .filter(e => {
+              if (!e.eventDate) return true;
+              const eventDate = e.eventDate.toDate ? e.eventDate.toDate() : new Date(e.eventDate as any);
+              return eventDate >= now;
+            })
+            .sort((a, b) => {
+              const dateA = a.eventDate?.toMillis ? a.eventDate.toMillis() : 0;
+              const dateB = b.eventDate?.toMillis ? b.eventDate.toMillis() : 0;
+              return dateA - dateB;
+            })
+            .slice(0, 3)
+        : [];
       setUpcomingEvents(events);
 
-      setRecentTickets(ticketsSnap.docs.map(d => ({ id: d.id, ...d.data() } as RecentTicket)));
-      setRecentBookings(bookingsSnap.docs.map(d => ({ id: d.id, ...d.data() } as RecentBooking)));
+      setRecentTickets(ticketsRes.status === 'fulfilled' ? ticketsRes.value.docs.map(d => ({ id: d.id, ...d.data() } as RecentTicket)) : []);
+      setRecentBookings(bookingsRes.status === 'fulfilled' ? bookingsRes.value.docs.map(d => ({ id: d.id, ...d.data() } as RecentBooking)) : []);
       setLoading(false);
     }
 
     loadDashboard().catch(err => {
       console.error('Dashboard load error:', err);
+      setLoadErrors(['dashboard data']);
       setLoading(false);
     });
   }, []);
@@ -90,6 +108,13 @@ export default function AdminDashboard() {
             <Plus size={16} /> New Post
           </Link>
         </div>
+
+        {loadErrors.length > 0 && (
+          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+            Failed to load: {loadErrors.join(', ')}. Check the browser console for details — this usually means a
+            Firestore permission or index error rather than missing data.
+          </div>
+        )}
 
         {loading ? (
           <div className="flex justify-center items-center h-48">

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -3,6 +3,7 @@ import { collection, query, where, orderBy, limit, getDocs, Timestamp } from 'fi
 import { db } from '../../lib/firebase';
 import { Link } from 'react-router-dom';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import { FileText, Calendar, Ticket, CalendarDays, Users, Plus, TrendingUp, BookOpen, Clock, Loader2 } from 'lucide-react';
 
 interface PostCounts { published: number; draft: number; archived: number; }
@@ -22,26 +23,31 @@ export default function AdminDashboard() {
     async function loadDashboard() {
       const now = new Date();
 
-      // Each query is settled independently so one failure (e.g. a permission
-      // or missing-index error) doesn't blank out the entire dashboard.
-      const results = await Promise.allSettled([
-        getDocs(query(collection(db, 'posts'), where('status', '==', 'published'))),
-        getDocs(query(collection(db, 'posts'), where('status', '==', 'draft'))),
-        getDocs(query(collection(db, 'posts'), where('status', '==', 'archived'))),
+      // Each query is labeled and settled independently so one failure (e.g. a
+      // permission or missing-index error) doesn't blank out the entire dashboard,
+      // and so an error can never be attributed to the wrong query.
+      const specs = [
+        { label: 'published posts', promise: getDocs(query(collection(db, 'posts'), where('status', '==', 'published'))) },
+        { label: 'draft posts', promise: getDocs(query(collection(db, 'posts'), where('status', '==', 'draft'))) },
+        { label: 'archived posts', promise: getDocs(query(collection(db, 'posts'), where('status', '==', 'archived'))) },
         // Equality-only filters (no orderBy chained) so this never depends on a
         // composite index existing — sort/filter for "upcoming" client-side instead.
-        getDocs(query(collection(db, 'posts'), where('type', '==', 'event'), where('status', '==', 'published'))),
-        getDocs(query(collection(db, 'tickets'), orderBy('purchasedAt', 'desc'), limit(5))),
-        getDocs(query(collection(db, 'bookings'), orderBy('submittedAt', 'desc'), limit(5))),
-      ]);
-      const [publishedRes, draftRes, archivedRes, eventsRes, ticketsRes, bookingsRes] = results;
+        // A generous limit still bounds the worst-case read as the event archive grows.
+        { label: 'upcoming events', promise: getDocs(query(collection(db, 'posts'), where('type', '==', 'event'), where('status', '==', 'published'), limit(50))) },
+        { label: 'recent tickets', promise: getDocs(query(collection(db, 'tickets'), orderBy('purchasedAt', 'desc'), limit(5))) },
+        { label: 'recent bookings', promise: getDocs(query(collection(db, 'bookings'), orderBy('submittedAt', 'desc'), limit(5))) },
+      ];
+      // `settled` is derived from `specs` by a single map(), so it's always the same
+      // length and order as `specs` — positionally destructuring it here is safe
+      // because label and query live together in one array, not two synced-by-hand ones.
+      const settled = await Promise.allSettled(specs.map(s => s.promise));
+      const [publishedRes, draftRes, archivedRes, eventsRes, ticketsRes, bookingsRes] = settled;
 
       const errors: string[] = [];
-      const labels = ['published posts', 'draft posts', 'archived posts', 'upcoming events', 'recent tickets', 'recent bookings'];
-      results.forEach((r, i) => {
-        if (r.status === 'rejected') {
-          console.error(`Dashboard: failed to load ${labels[i]}:`, r.reason);
-          errors.push(labels[i]);
+      specs.forEach((s, i) => {
+        if (settled[i].status === 'rejected') {
+          console.error(`Dashboard: failed to load ${s.label}:`, (settled[i] as PromiseRejectedResult).reason);
+          errors.push(s.label);
         }
       });
       setLoadErrors(errors);
@@ -55,16 +61,10 @@ export default function AdminDashboard() {
       const events: UpcomingEvent[] = eventsRes.status === 'fulfilled'
         ? eventsRes.value.docs
             .map(d => ({ id: d.id, ...d.data() } as UpcomingEvent))
-            .filter(e => {
-              if (!e.eventDate) return true;
-              const eventDate = e.eventDate.toDate ? e.eventDate.toDate() : new Date(e.eventDate as any);
-              return eventDate >= now;
-            })
-            .sort((a, b) => {
-              const dateA = a.eventDate?.toMillis ? a.eventDate.toMillis() : 0;
-              const dateB = b.eventDate?.toMillis ? b.eventDate.toMillis() : 0;
-              return dateA - dateB;
-            })
+            // An event with no scheduled date isn't "upcoming" — exclude it, matching
+            // what the previous Firestore-side orderBy('eventDate') silently did.
+            .filter(e => e.eventDate && (e.eventDate.toDate ? e.eventDate.toDate() : new Date(e.eventDate as any)) >= now)
+            .sort((a, b) => (a.eventDate?.toMillis() ?? 0) - (b.eventDate?.toMillis() ?? 0))
             .slice(0, 3)
         : [];
       setUpcomingEvents(events);
@@ -109,12 +109,7 @@ export default function AdminDashboard() {
           </Link>
         </div>
 
-        {loadErrors.length > 0 && (
-          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
-            Failed to load: {loadErrors.join(', ')}. Check the browser console for details — this usually means a
-            Firestore permission or index error rather than missing data.
-          </div>
-        )}
+        {loadErrors.length > 0 && <ErrorBanner message={`Failed to load: ${loadErrors.join(', ')}.`} />}
 
         {loading ? (
           <div className="flex justify-center items-center h-48">

--- a/src/pages/admin/BookingsAdmin.tsx
+++ b/src/pages/admin/BookingsAdmin.tsx
@@ -4,10 +4,12 @@ import type { Booking } from '../../types';
 import { format, parseISO } from 'date-fns';
 import { Calendar, Clock, User, Building, Mail, FileText, CheckCircle, XCircle } from 'lucide-react';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 
 export default function BookingsAdmin() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'pending' | 'confirmed' | 'cancelled'>('pending');
 
   useEffect(() => {
@@ -16,13 +18,15 @@ export default function BookingsAdmin() {
 
   const loadBookings = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const data = await getAllBookings();
       // Sort by date descending (newest bookings first)
       const sortedData = data.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
       setBookings(sortedData);
-    } catch (error) {
+    } catch (error: any) {
       console.error("Failed to load bookings", error);
+      setLoadError(error?.message || 'Failed to load bookings.');
     } finally {
       setLoading(false);
     }
@@ -60,7 +64,9 @@ export default function BookingsAdmin() {
 
       {/* Main Content */}
       <main className="flex-grow p-8 max-w-7xl mx-auto w-full">
-        
+
+        {loadError && <ErrorBanner message={`Failed to load bookings: ${loadError}.`} />}
+
         {/* Tabs */}
         <div className="flex gap-4 mb-8 border-b border-tan-light">
           {(['pending', 'confirmed', 'cancelled'] as const).map(tab => (

--- a/src/pages/admin/ContentAdmin.tsx
+++ b/src/pages/admin/ContentAdmin.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { collection, query, getDocs, addDoc, updateDoc, doc, serverTimestamp, orderBy, where, writeBatch } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import RichTextEditor from '../../components/admin/RichTextEditor';
 import { Pencil, Archive, Plus, ArrowLeft, Ticket as TicketIcon, Upload, Trash2, Eye, CheckSquare, Square, X, Link2, Check } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -791,12 +792,7 @@ export default function ContentAdmin() {
               </button>
             </div>
 
-            {loadError && (
-              <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
-                Failed to load posts: {loadError}. Check the browser console — this usually means a Firestore
-                permissions issue rather than there being no content.
-              </div>
-            )}
+            {loadError && <ErrorBanner message={`Failed to load posts: ${loadError}.`} />}
 
             {selectedIds.size > 0 && (
               <div className="mb-4 flex items-center gap-3 bg-tan/10 border border-tan/30 rounded-lg px-4 py-3">

--- a/src/pages/admin/ContentAdmin.tsx
+++ b/src/pages/admin/ContentAdmin.tsx
@@ -43,6 +43,7 @@ interface Post {
 export default function ContentAdmin() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [editingPost, setEditingPost] = useState<Post | Partial<Post> | null>(null);
   const [uploadingDoc, setUploadingDoc] = useState(false);
   const [uploadingImageField, setUploadingImageField] = useState<string | null>(null);
@@ -300,6 +301,7 @@ export default function ContentAdmin() {
 
   const fetchPosts = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const q = query(collection(db, 'posts'), orderBy('createdAt', 'desc'));
       const snapshot = await getDocs(q);
@@ -312,8 +314,9 @@ export default function ContentAdmin() {
         return { id: doc.id, ...data, category } as Post;
       });
       setPosts(fetchedPosts);
-    } catch (err) {
+    } catch (err: any) {
       console.error("Error fetching posts:", err);
+      setLoadError(err?.message || 'Failed to load posts.');
     } finally {
       setLoading(false);
     }
@@ -787,6 +790,13 @@ export default function ContentAdmin() {
                 New Post
               </button>
             </div>
+
+            {loadError && (
+              <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+                Failed to load posts: {loadError}. Check the browser console — this usually means a Firestore
+                permissions issue rather than there being no content.
+              </div>
+            )}
 
             {selectedIds.size > 0 && (
               <div className="mb-4 flex items-center gap-3 bg-tan/10 border border-tan/30 rounded-lg px-4 py-3">

--- a/src/pages/admin/ShortLinksAdmin.tsx
+++ b/src/pages/admin/ShortLinksAdmin.tsx
@@ -4,6 +4,7 @@ import { db } from '../../lib/firebase';
 import type { ShortLink } from '../../types';
 import { Loader2, Link as LinkIcon, Trash2, ExternalLink } from 'lucide-react';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import { format } from 'date-fns';
 
 export default function ShortLinksAdmin() {
@@ -136,12 +137,7 @@ export default function ShortLinksAdmin() {
           </form>
         </div>
 
-        {loadError && (
-          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
-            Failed to load shortlinks: {loadError}. Check the browser console — this usually means a Firestore
-            permissions issue rather than there being no links.
-          </div>
-        )}
+        {loadError && <ErrorBanner message={`Failed to load shortlinks: ${loadError}.`} />}
 
         {/* Links List */}
         {loading ? (

--- a/src/pages/admin/ShortLinksAdmin.tsx
+++ b/src/pages/admin/ShortLinksAdmin.tsx
@@ -9,6 +9,7 @@ import { format } from 'date-fns';
 export default function ShortLinksAdmin() {
   const [links, setLinks] = useState<ShortLink[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   
   const [newSlug, setNewSlug] = useState('');
   const [newTarget, setNewTarget] = useState('');
@@ -23,12 +24,14 @@ export default function ShortLinksAdmin() {
   const loadLinks = async () => {
     try {
       setLoading(true);
+      setLoadError(null);
       const q = query(collection(db, 'shortlinks'), orderBy('createdAt', 'desc'));
       const snapshot = await getDocs(q);
       const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as ShortLink));
       setLinks(data);
-    } catch (err) {
+    } catch (err: any) {
       console.error('Failed to load shortlinks', err);
+      setLoadError(err?.message || 'Failed to load shortlinks.');
     } finally {
       setLoading(false);
     }
@@ -132,6 +135,13 @@ export default function ShortLinksAdmin() {
             </button>
           </form>
         </div>
+
+        {loadError && (
+          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+            Failed to load shortlinks: {loadError}. Check the browser console — this usually means a Firestore
+            permissions issue rather than there being no links.
+          </div>
+        )}
 
         {/* Links List */}
         {loading ? (

--- a/src/pages/admin/TicketsAdmin.tsx
+++ b/src/pages/admin/TicketsAdmin.tsx
@@ -5,6 +5,7 @@ import { db } from '../../lib/firebase';
 import type { Ticket } from '../../types';
 import { Ticket as TicketIcon, Loader2, Search, X, QrCode, ScanLine } from 'lucide-react';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import { Link } from 'react-router-dom';
 import { format } from 'date-fns';
 
@@ -13,6 +14,7 @@ type FilterTab = 'all' | 'paid' | 'cancelled';
 export default function TicketsAdmin() {
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [filterTab, setFilterTab] = useState<FilterTab>('all');
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
@@ -23,8 +25,9 @@ export default function TicketsAdmin() {
       try {
         const data = await getTickets();
         setTickets(data.sort((a, b) => new Date(b.purchasedAt).getTime() - new Date(a.purchasedAt).getTime()));
-      } catch (err) {
+      } catch (err: any) {
         console.error('Failed to load tickets', err);
+        setLoadError(err?.message || 'Failed to load tickets.');
       } finally {
         setLoading(false);
       }
@@ -113,6 +116,8 @@ export default function TicketsAdmin() {
             </Link>
           </div>
         </header>
+
+        {loadError && <ErrorBanner message={`Failed to load tickets: ${loadError}.`} />}
 
         {/* Search + Filters */}
         <div className="flex flex-col sm:flex-row gap-4 mb-6">

--- a/src/pages/admin/UsersAdmin.tsx
+++ b/src/pages/admin/UsersAdmin.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { collection, query, getDocs, setDoc, deleteDoc, doc } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import { Pencil, Trash2, Plus, ArrowLeft } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Navigate } from 'react-router-dom';
@@ -15,10 +16,12 @@ export default function UsersAdmin() {
   const { isAdmin, user } = useAuth();
   const [users, setUsers] = useState<UserRole[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [editingUser, setEditingUser] = useState<UserRole | Partial<UserRole> | null>(null);
 
   const fetchUsers = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const q = query(collection(db, 'user_roles'));
       const snapshot = await getDocs(q);
@@ -27,8 +30,9 @@ export default function UsersAdmin() {
         role: doc.data().role
       } as UserRole));
       setUsers(fetchedUsers);
-    } catch (err) {
+    } catch (err: any) {
       console.error("Error fetching users:", err);
+      setLoadError(err?.message || 'Failed to load user roles.');
     } finally {
       setLoading(false);
     }
@@ -156,6 +160,8 @@ export default function UsersAdmin() {
                 Add User
               </button>
             </div>
+
+            {loadError && <ErrorBanner message={`Failed to load user roles: ${loadError}.`} />}
 
             {loading ? (
               <div className="text-center py-12 text-charcoal/60">Loading users...</div>

--- a/src/pages/admin/VolunteersAdmin.tsx
+++ b/src/pages/admin/VolunteersAdmin.tsx
@@ -29,6 +29,7 @@ export default function VolunteersAdmin() {
   const [view, setView] = useState<View>('list');
   const [sheets, setSheets] = useState<VolunteerSheet[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
@@ -45,8 +46,16 @@ export default function VolunteersAdmin() {
 
   const fetchSheets = useCallback(async () => {
     setLoading(true);
-    setSheets(await getVolunteerSheets());
-    setLoading(false);
+    setLoadError(null);
+    try {
+      setSheets(await getVolunteerSheets());
+    } catch (err: any) {
+      console.error('Error fetching volunteer sheets:', err);
+      setLoadError(err?.message || 'Failed to load volunteer sheets.');
+      setSheets([]);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   const fetchEventOptions = useCallback(async () => {
@@ -440,6 +449,13 @@ export default function VolunteersAdmin() {
             </button>
           )}
         </div>
+
+        {loadError && (
+          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+            Failed to load volunteer sheets: {loadError}. Check the browser console — this usually means a Firestore
+            permissions issue rather than there being no data.
+          </div>
+        )}
 
         {loading ? (
           <div className="text-center py-12 text-charcoal/60">Loading volunteer sheets...</div>

--- a/src/pages/admin/VolunteersAdmin.tsx
+++ b/src/pages/admin/VolunteersAdmin.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { collection, query, getDocs, orderBy } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import RichTextEditor from '../../components/admin/RichTextEditor';
 import { useAuth } from '../../contexts/AuthContext';
 import {
@@ -450,12 +451,7 @@ export default function VolunteersAdmin() {
           )}
         </div>
 
-        {loadError && (
-          <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
-            Failed to load volunteer sheets: {loadError}. Check the browser console — this usually means a Firestore
-            permissions issue rather than there being no data.
-          </div>
-        )}
+        {loadError && <ErrorBanner message={`Failed to load volunteer sheets: ${loadError}.`} />}
 
         {loading ? (
           <div className="text-center py-12 text-charcoal/60">Loading volunteer sheets...</div>

--- a/src/pages/admin/WikiAdmin.tsx
+++ b/src/pages/admin/WikiAdmin.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { collection, query, getDocs, addDoc, updateDoc, deleteDoc, doc, serverTimestamp, orderBy } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
+import ErrorBanner from '../../components/admin/ErrorBanner';
 import RichTextEditor from '../../components/admin/RichTextEditor';
 import { Pencil, Trash2, Plus, ArrowLeft } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -162,12 +163,7 @@ export default function WikiAdmin() {
               </button>
             </div>
 
-            {loadError && (
-              <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
-                Failed to load wiki pages: {loadError}. Check the browser console — this usually means a Firestore
-                permissions issue rather than there being no pages.
-              </div>
-            )}
+            {loadError && <ErrorBanner message={`Failed to load wiki pages: ${loadError}.`} />}
 
             {loading ? (
               <div className="text-center py-12 text-charcoal/60">Loading wiki...</div>

--- a/src/pages/admin/WikiAdmin.tsx
+++ b/src/pages/admin/WikiAdmin.tsx
@@ -20,18 +20,21 @@ interface WikiPage {
 export default function WikiAdmin() {
   const [pages, setPages] = useState<WikiPage[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [editingPage, setEditingPage] = useState<WikiPage | Partial<WikiPage> | null>(null);
   const { user } = useAuth();
 
   const fetchPages = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const q = query(collection(db, 'wiki'), orderBy('category'), orderBy('title'));
       const snapshot = await getDocs(q);
       const fetchedPages = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as WikiPage));
       setPages(fetchedPages);
-    } catch (err) {
+    } catch (err: any) {
       console.error("Error fetching wiki pages:", err);
+      setLoadError(err?.message || 'Failed to load wiki pages.');
     } finally {
       setLoading(false);
     }
@@ -158,6 +161,13 @@ export default function WikiAdmin() {
                 New Page
               </button>
             </div>
+
+            {loadError && (
+              <div className="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-red-800 font-sans text-sm">
+                Failed to load wiki pages: {loadError}. Check the browser console — this usually means a Firestore
+                permissions issue rather than there being no pages.
+              </div>
+            )}
 
             {loading ? (
               <div className="text-center py-12 text-charcoal/60">Loading wiki...</div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -189,18 +189,14 @@ export async function getBookings(startDate: string, endDate: string): Promise<B
   }
 }
 
+/** Fetch all bookings (admin view). Throws on failure so the caller can surface the error. */
 export async function getAllBookings(): Promise<Booking[]> {
-  try {
-    const q = query(
-      collection(db, 'bookings'),
-      orderBy('submittedAt', 'desc')
-    );
-    const snapshot = await getDocs(q);
-    return snapshot.docs.map(toBooking);
-  } catch (err) {
-    console.error('Error fetching all bookings:', err);
-    return [];
-  }
+  const q = query(
+    collection(db, 'bookings'),
+    orderBy('submittedAt', 'desc')
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(toBooking);
 }
 
 export async function updateBookingStatus(id: string, status: 'pending' | 'confirmed' | 'cancelled'): Promise<void> {
@@ -329,18 +325,14 @@ export async function getMemberships(): Promise<Membership[]> {
   }
 }
 
+/** Fetch all tickets (admin view). Throws on failure so the caller can surface the error. */
 export async function getTickets(): Promise<Ticket[]> {
-  try {
-    const q = query(
-      collection(db, 'tickets'),
-      orderBy('purchasedAt', 'desc')
-    );
-    const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Ticket));
-  } catch (err) {
-    console.error('Error fetching tickets:', err);
-    return [];
-  }
+  const q = query(
+    collection(db, 'tickets'),
+    orderBy('purchasedAt', 'desc')
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Ticket));
 }
 
 // ── Volunteer Management ──────────────────────────────────────────────────────

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -369,16 +369,11 @@ function generateShareToken(): string {
   return Math.random().toString(36).substring(2, 10);
 }
 
-/** Fetch all volunteer sheets (admin view) */
+/** Fetch all volunteer sheets (admin view). Throws on failure so the caller can surface the error. */
 export async function getVolunteerSheets(): Promise<VolunteerSheet[]> {
-  try {
-    const q = query(collection(db, 'volunteer_sheets'), orderBy('createdAt', 'desc'));
-    const snapshot = await getDocs(q);
-    return snapshot.docs.map(d => ({ id: d.id, ...d.data() } as VolunteerSheet));
-  } catch (err) {
-    console.error('Error fetching volunteer sheets:', err);
-    return [];
-  }
+  const q = query(collection(db, 'volunteer_sheets'), orderBy('createdAt', 'desc'));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(d => ({ id: d.id, ...d.data() } as VolunteerSheet));
 }
 
 /** Fetch a single active sheet by its public share token */


### PR DESCRIPTION
## Root cause

`.github/workflows/deploy.yml` only ran:

```
npx firebase-tools deploy --only hosting,functions --project sahs-archives --force
```

`firestore:rules` (and storage rules) were never included. So every time `firestore.rules` was updated and merged to `main`, the change looked deployed (hosting + functions succeeded) but never actually reached production Firestore. Production kept running whatever rules were last pushed manually.

This explains the recurring "no content in the admin portal" symptom: newer collections (like `volunteer_sheets`) have rules in the repo, but if those rules were never manually deployed, production falls through to the catch-all `allow read, write: if false` and every read gets `permission-denied`. Every list-fetch in the codebase wraps Firestore calls in try/catch and silently returns `[]`/logs to console on error — so a permissions failure looks identical to "no data," with nothing in the UI to indicate what actually happened.

## Changes

**Deploy pipeline**
- `.github/workflows/deploy.yml`: split into an app-deploy step (`hosting,functions` — the proven path) and a separate rules-deploy step (`firestore:rules,storage`), with a `--dry-run` validation step in between. This means a problem deploying rules (e.g. a missing IAM role for the CI service account, or a rules syntax error) can't block the app from shipping, and can't reach production without at least a dry-run check first.
- `firestore:indexes` is intentionally **not** included in the automated deploy — `firebase deploy --only firestore:indexes` is declarative and deletes any production index not listed in `firestore.indexes.json`, which is too destructive to run unattended on every push. Index changes stay a manual, deliberate step per CLAUDE.md.

**Security**
- `firestore.rules`: added the missing `shortlinks` rule (it had no rule at all, so it always fell through to the default deny).
- `firestore.rules`: `isAdmin()` had a broad `.matches('.*@senoiahistory\.com$')` clause that granted admin rights to *any* staff email, not just permanent admins or an explicit admin-role override. Removed it so the role hierarchy CLAUDE.md documents (permanent admins + admin-role override only) is actually enforced — this had been silently over-permissive since rules were never live before this PR.

**Correctness**
- `BoxOffice.tsx` ran the same `where`+`where`+`orderBy` query pattern that broke `AdminDashboard`, needing a 3-field composite index that was never declared. Rewritten to the same equality-filters-then-client-sort pattern used elsewhere, so it no longer depends on any composite index.
- `AdminDashboard`: switched `Promise.all` → `Promise.allSettled` so one failing query can't blank the whole dashboard; replaced two separately-maintained arrays (query results + error labels, which could drift and mislabel an error) with a single array of `{label, promise}` pairs; excluded event posts with no `eventDate` from "Upcoming Events" instead of sorting them to the top; added a generous `limit(50)` so the events query stays bounded as the archive grows.

**Completeness** — closed the remaining silent-failure gaps, not just on the pages the bug report named:
- `api.ts`: `getAllBookings()` and `getTickets()` now throw instead of swallowing errors, matching `getVolunteerSheets()`.
- `UsersAdmin`, `BookingsAdmin`, `TicketsAdmin` now surface load errors visibly instead of console-only logging.
- Extracted the duplicated error-banner markup into a shared `src/components/admin/ErrorBanner.tsx`, used by all 8 admin pages that read Firestore directly (Dashboard, Content, Volunteers, Short Links, Wiki, Users, Bookings, Tickets).

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npm run build` — succeeds
- [ ] After merge, confirm the deploy workflow's rules-deploy step succeeds
- [ ] Confirm `/admin/volunteers`, `/admin/content`, `/admin/shortlinks`, `/admin/wiki`, `/admin/users`, `/admin/bookings`, `/admin/tickets`, and `/admin` (dashboard) show data (or a clear error banner, not silent blankness) after the deploy completes
- [ ] Confirm the CI service account has IAM permissions for `firestore:rules` and `storage` deploy targets (Firebase Rules Admin / Storage Admin or equivalent) — the new rules-deploy step will surface this clearly as its own failed step if not
