### PR TITLE
Add on/off toggle and explicit sheet link for event volunteer signup

### DIFF
--- a/src/pages/NewsDetail.tsx
+++ b/src/pages/NewsDetail.tsx
@@ -4,7 +4,7 @@ import { collection, query, where, getDocs, limit } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import type { Post, VolunteerSheet } from '../types';
 import { useAuth } from '../contexts/AuthContext';
-import { getActiveVolunteerSheetByPostId } from '../services/api';
+import { getVolunteerSheetById } from '../services/api';
 import { Calendar, MapPin, Download, FileText, HandHelping } from 'lucide-react';
 import Lightbox from 'yet-another-react-lightbox';
 import Counter from 'yet-another-react-lightbox/plugins/counter';
@@ -34,8 +34,8 @@ export default function NewsDetail() {
           const docSnap = snapshot.docs[0];
           const loadedPost = { id: docSnap.id, ...docSnap.data() } as Post;
           setPost(loadedPost);
-          if (loadedPost.type === 'event') {
-            const sheet = await getActiveVolunteerSheetByPostId(loadedPost.id);
+          if (loadedPost.type === 'event' && loadedPost.volunteerSheetId) {
+            const sheet = await getVolunteerSheetById(loadedPost.volunteerSheetId);
             setVolunteerSheet(sheet);
           }
         }

--- a/src/pages/admin/ContentAdmin.tsx
+++ b/src/pages/admin/ContentAdmin.tsx
@@ -4,9 +4,11 @@ import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
 import ErrorBanner from '../../components/admin/ErrorBanner';
 import RichTextEditor from '../../components/admin/RichTextEditor';
-import { Pencil, Archive, Plus, ArrowLeft, Ticket as TicketIcon, Upload, Trash2, Eye, CheckSquare, Square, X, Link2, Check } from 'lucide-react';
+import { Pencil, Archive, Plus, ArrowLeft, Ticket as TicketIcon, Upload, Trash2, Eye, CheckSquare, Square, X, Link2, Check, HandHelping } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { uploadFile } from '../../services/storage';
+import { getVolunteerSheets } from '../../services/api';
+import type { VolunteerSheet } from '../../types';
 
 const timestampToLocalISO = (timestamp: any): string => {
   if (!timestamp) return '';
@@ -35,9 +37,12 @@ interface Post {
   capacity?: number | null;
   ticketsSold?: number;
   galleryImages?: string[];
+  // Volunteer signup fields (stored in Firestore)
+  volunteerSheetId?: string | null;
   // Editor-only ephemeral fields (stripped before save)
   _enableTicketing?: boolean;
   _ticketPriceDisplay?: string;
+  _enableVolunteer?: boolean;
   [key: string]: any;
 }
 
@@ -54,6 +59,7 @@ export default function ContentAdmin() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkLoading, setBulkLoading] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const [volunteerSheets, setVolunteerSheets] = useState<VolunteerSheet[]>([]);
   const { user } = useAuth();
 
   const startEditing = (post: Post) => {
@@ -64,11 +70,13 @@ export default function ContentAdmin() {
       publishDateDisplay: post.publishDate ? timestampToLocalISO(post.publishDate) : '',
       _ticketPriceDisplay: post.ticketPrice ? (post.ticketPrice / 100).toFixed(2) : '',
       _enableTicketing: !!post.ticketPrice,
+      _enableVolunteer: !!post.volunteerSheetId,
     });
   };
 
   useEffect(() => {
     fetchPosts();
+    getVolunteerSheets().then(setVolunteerSheets).catch(err => console.error('Error fetching volunteer sheets:', err));
   }, []);
 
   const handleSave = async (e: React.FormEvent) => {
@@ -136,6 +144,12 @@ export default function ContentAdmin() {
         // Clean up display-only fields
         delete postData._enableTicketing;
         delete postData._ticketPriceDisplay;
+
+        // Volunteer signup link
+        postData.volunteerSheetId = editingPost._enableVolunteer && editingPost.volunteerSheetId
+          ? editingPost.volunteerSheetId
+          : null;
+        delete postData._enableVolunteer;
       }
 
       if (editingPost.id) {
@@ -522,6 +536,47 @@ export default function ContentAdmin() {
                             <span className="ml-2 text-xs text-charcoal/40">(read-only)</span>
                           </div>
                         </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Volunteer Signup Panel */}
+                  <div className="bg-white border border-tan-light rounded-lg p-5">
+                    <div className="flex items-center justify-between mb-4">
+                      <div className="flex items-center gap-2">
+                        <HandHelping size={16} className="text-tan" />
+                        <p className="text-sm font-bold text-charcoal uppercase tracking-wider">Volunteer Signup</p>
+                      </div>
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <span className="text-sm text-charcoal/60">{editingPost._enableVolunteer ? 'Enabled' : 'Disabled'}</span>
+                        <div
+                          onClick={() => setEditingPost(p => p ? ({ ...p, _enableVolunteer: !p._enableVolunteer }) : p)}
+                          className={`w-11 h-6 rounded-full transition-colors relative cursor-pointer ${
+                            editingPost._enableVolunteer ? 'bg-tan' : 'bg-charcoal/20'
+                          }`}
+                        >
+                          <div className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                            editingPost._enableVolunteer ? 'translate-x-5' : 'translate-x-0'
+                          }`} />
+                        </div>
+                      </label>
+                    </div>
+
+                    {editingPost._enableVolunteer && (
+                      <div>
+                        <label className="block text-xs font-bold text-charcoal/60 uppercase tracking-wider mb-1">Volunteer Sheet</label>
+                        <select
+                          required
+                          value={editingPost.volunteerSheetId || ''}
+                          onChange={e => setEditingPost(p => p ? ({ ...p, volunteerSheetId: e.target.value }) : p)}
+                          className="w-full px-3 py-2 border border-tan-light rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-tan/50 bg-white"
+                        >
+                          <option value="">— Select a volunteer sheet —</option>
+                          {volunteerSheets.map(sheet => (
+                            <option key={sheet.id} value={sheet.id}>{sheet.title} ({sheet.status})</option>
+                          ))}
+                        </select>
+                        <p className="text-xs text-charcoal/40 mt-1">Manage sheets and slots under Admin → Volunteers.</p>
                       </div>
                     )}
                   </div>

--- a/src/pages/admin/VolunteersAdmin.tsx
+++ b/src/pages/admin/VolunteersAdmin.tsx
@@ -484,6 +484,11 @@ export default function VolunteersAdmin() {
                   <tr key={sheet.id} className="border-b border-tan-light/50 last:border-0 hover:bg-cream/50 transition-colors">
                     <td className="p-4">
                       <p className="font-serif text-charcoal font-medium">{sheet.title}</p>
+                      {sheet.eventPostId && (
+                        <p className="text-xs text-tan mt-0.5">
+                          🔗 {eventOptions.find(e => e.id === sheet.eventPostId)?.title || 'Linked event (not found)'}
+                        </p>
+                      )}
                       {sheet.eventLocation && <p className="text-xs text-charcoal/50 mt-0.5">📍 {sheet.eventLocation}</p>}
                     </td>
                     <td className="p-4">{statusBadge(sheet.status)}</td>

--- a/src/pages/admin/VolunteersAdmin.tsx
+++ b/src/pages/admin/VolunteersAdmin.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { collection, query, getDocs, orderBy } from 'firebase/firestore';
+import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import AdminHeader from './AdminHeader';
 import ErrorBanner from '../../components/admin/ErrorBanner';
@@ -61,12 +61,15 @@ export default function VolunteersAdmin() {
 
   const fetchEventOptions = useCallback(async () => {
     try {
-      const q = query(collection(db, 'posts'), orderBy('eventDate', 'asc'));
-      const snap = await getDocs(q);
+      // Fetch all posts and sort in memory — Firestore's orderBy excludes documents
+      // missing the ordered field entirely, which would silently drop legacy event
+      // posts without an eventDate (see conductor/fix-news-events.md).
+      const snap = await getDocs(collection(db, 'posts'));
       const events = snap.docs
         .map(d => ({ id: d.id, ...d.data() } as any))
         .filter((p: any) => p.type === 'event' || p.category === 'Event')
-        .map((p: any) => ({ id: p.id, title: p.title, eventDate: p.eventDate, location: p.location || p.eventLocation }));
+        .map((p: any) => ({ id: p.id, title: p.title, eventDate: p.eventDate, location: p.location || p.eventLocation }))
+        .sort((a, b) => (a.eventDate?.toMillis() || 0) - (b.eventDate?.toMillis() || 0));
       setEventOptions(events);
     } catch { /* ignore */ }
   }, []);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -337,25 +337,6 @@ export async function getTickets(): Promise<Ticket[]> {
 
 // ── Volunteer Management ──────────────────────────────────────────────────────
 
-/** Fetch the active volunteer sheet linked to a specific event post (public) */
-export async function getActiveVolunteerSheetByPostId(postId: string): Promise<VolunteerSheet | null> {
-  try {
-    const q = query(
-      collection(db, 'volunteer_sheets'),
-      where('eventPostId', '==', postId),
-      where('status', '==', 'active'),
-      limit(1)
-    );
-    const snapshot = await getDocs(q);
-    if (snapshot.empty) return null;
-    const d = snapshot.docs[0];
-    return { id: d.id, ...d.data() } as VolunteerSheet;
-  } catch (err) {
-    console.error('Error fetching volunteer sheet by post ID:', err);
-    return null;
-  }
-}
-
 /** Generate a random URL-safe token for volunteer sheet share links */
 function generateShareToken(): string {
   return Math.random().toString(36).substring(2, 10);
@@ -366,6 +347,18 @@ export async function getVolunteerSheets(): Promise<VolunteerSheet[]> {
   const q = query(collection(db, 'volunteer_sheets'), orderBy('createdAt', 'desc'));
   const snapshot = await getDocs(q);
   return snapshot.docs.map(d => ({ id: d.id, ...d.data() } as VolunteerSheet));
+}
+
+/** Fetch a specific volunteer sheet by ID if it's active (public). Denied/missing sheets resolve to null rather than throwing. */
+export async function getVolunteerSheetById(id: string): Promise<VolunteerSheet | null> {
+  try {
+    const snap = await getDoc(doc(db, 'volunteer_sheets', id));
+    if (!snap.exists() || snap.data().status !== 'active') return null;
+    return { id: snap.id, ...snap.data() } as VolunteerSheet;
+  } catch (err) {
+    console.error('Error fetching volunteer sheet by ID:', err);
+    return null;
+  }
 }
 
 /** Fetch a single active sheet by its public share token */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,10 @@ export interface Post {
   ticketPrice?: number; // in cents
   capacity?: number;
   ticketsSold?: number;
-  
+
+  // Volunteer signup fields
+  volunteerSheetId?: string | null;
+
   // System Fields
   createdAt: Timestamp | null;
   updatedAt: Timestamp | null;


### PR DESCRIPTION
## Summary
- Adds a **Volunteer Signup** panel to the post editor (`ContentAdmin.tsx`), mirroring the existing Ticketing toggle — an on/off switch plus a dropdown to link a specific volunteer sheet to an event post.
- The public event page (`NewsDetail.tsx`) now only shows the "Volunteer for This Event" box when a post has an explicit `volunteerSheetId` linked, replacing the previous behavior of auto-matching any active sheet whose `eventPostId` pointed at the post (which had no on/off control short of changing the sheet's own status).
- The Volunteers admin list (`VolunteersAdmin.tsx`) now shows the linked event's title next to each sheet, so a correctly-linked sheet with a generic title (e.g. "Volunteer Sign Up") isn't mistaken for orphaned.
- `getActiveVolunteerSheetByPostId` (auto-match by `eventPostId`) removed from `api.ts` as dead code, replaced by `getVolunteerSheetById`.

## Why
Reported issue: the volunteer signup box was stuck showing on a past event's page (Hot Rods for History) with no way to turn it off, and the linked volunteer sheet looked "orphaned" in the admin list even though it was correctly linked via `eventPostId`.

## Test plan
Verified end-to-end against the Firebase emulator (signed in as admin):
- [x] Created a test event post, enabled the Volunteer Signup toggle, linked a sheet, saved — confirmed `volunteerSheetId` persisted in Firestore and the box rendered on the public page with the correct sheet title.
- [x] Disabled the toggle, saved — confirmed `volunteerSheetId` cleared to `null` and the box disappeared from the public page.
- [x] Confirmed the existing Ticketing toggle still works unaffected (regression check).
- [x] `npx tsc --noEmit` passes with no errors.
- [ ] Manually verify in production: open the real Hot Rods for History 2026 post, turn off Volunteer Signup (or link the correct sheet), save.